### PR TITLE
add :reminders attribute to fix API parsing error

### DIFF
--- a/lib/habitica_client/user/task.rb
+++ b/lib/habitica_client/user/task.rb
@@ -22,7 +22,7 @@ class HabiticaClient::User
                   :type, :tags, :checklist, :value, :priority,
                   :challenge, :down, :up, :history, :streak,
                   :frequency, :history, :completed, :every_x, :repeat,
-                  :collapse_checklist
+                  :collapse_checklist, :reminders
 
     date_accessor :date_created, :date_completed, :start_date, :date
 


### PR DESCRIPTION
``` ruby
habit.user.tasks.first  # throws

NoMethodError: undefined method `reminders=' for #<HabiticaClient::User::Task:0x007f9c6acb4c48 @text="Wake Up">
```
